### PR TITLE
Add support for excellent homework

### DIFF
--- a/src/assets/translations/en.ts
+++ b/src/assets/translations/en.ts
@@ -187,4 +187,5 @@ export default {
   becomeMaintainer: 'Become a Maintainer',
   maintainerDescription:
     "Do you want to become a maintainer of learnX? Let's talk! Experience in frontend development is required, preferably with React.js; experience with React Native is a plus. Send an email to",
+  anonymous: 'Anonymous',
 };

--- a/src/assets/translations/zh.ts
+++ b/src/assets/translations/zh.ts
@@ -180,6 +180,7 @@ const zh: typeof en = {
   becomeMaintainer: '成为维护者',
   maintainerDescription:
     '你想成为 learnX 的维护者吗？让我们聊聊吧！要求有前端开发经验，最好是 React.js；有 React Native 经验者优先。请发送邮件至',
+  anonymous: '匿名',
 };
 
 export default zh;

--- a/src/components/AssignmentCard.tsx
+++ b/src/components/AssignmentCard.tsx
@@ -30,6 +30,7 @@ const AssignmentCard: React.FC<
     graded,
     answerContent,
     answerAttachment,
+    excellentHomeworkList,
   },
   hideCourseName,
   ...restProps
@@ -73,6 +74,14 @@ const AssignmentCard: React.FC<
                 style={styles.icon}
                 name="key-variant"
                 color={Colors.blue500}
+                size={16}
+              />
+            )}
+            {excellentHomeworkList && (
+              <MaterialCommunityIcons
+                style={styles.icon}
+                name="medal"
+                color={Colors.yellow500}
                 size={16}
               />
             )}

--- a/src/components/AssignmentCard.tsx
+++ b/src/components/AssignmentCard.tsx
@@ -77,7 +77,7 @@ const AssignmentCard: React.FC<
                 size={16}
               />
             )}
-            {excellentHomeworkList && (
+            {(excellentHomeworkList ?? []).length > 0 && (
               <MaterialCommunityIcons
                 style={styles.icon}
                 name="medal"

--- a/src/data/mock.ts
+++ b/src/data/mock.ts
@@ -516,6 +516,92 @@ const mockStore: PersistAppState = {
         url: 'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
         graded: false,
       },
+      {
+        id: '26ef84e8937624450193ba443c9414bd',
+        title: '超多优秀作业测试',
+        deadline: new Date(1599753540000).toISOString(),
+        completionType: HomeworkCompletionType.INDIVIDUAL,
+        submissionType: HomeworkSubmissionType.OFFLINE,
+        isLateSubmission: false,
+        submitted: true,
+        description: '<p>手写，下堂课随堂交。</p>',
+        submittedContent:
+          '<!-- <span style="line-height: 24px;"> -->\r\n\t\t\t\t\t\t\t\t\t\t<span style="line-height:2;">hello world\r\n\t\t\t\t\t\t\t\t\t\thello world</span>',
+        submittedAttachment: {
+          id: '1238990181_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+          name: '作业1111111111111111111111111111111111111111111111111111111111111111111111.pdf',
+          downloadUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          previewUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          size: '239.54KB',
+        },
+        attachment: {
+          id: '1238990183_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+          name: '小作业1.pdf',
+          downloadUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          previewUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          size: '239.54KB',
+        },
+        courseId: '2019-2020-1139283212',
+        studentHomeworkId: '1',
+        courseName: '通信与网络',
+        courseTeacherName: '周世东',
+        url: 'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+        graded: true,
+        grade: 80,
+        gradeContent:
+          '<!-- <span style="line-height: 24px;"> -->\r\n\t\t\t\t\t\t\t\t\t\t<span style="line-height:2;">hello world\r\n\t\t\t\t\t\t\t\t\t\thello world</span>',
+        gradeAttachment: {
+          id: '123899018d_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+          name: '作业1111111111111111111111111111111111111111111111111111111111111111111111.pdf',
+          downloadUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          previewUrl:
+            'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          size: '239.54KB',
+        },
+        answerContent: '答案已上传',
+        excellentHomeworkList: Array.from({length: 10}, (_, index) => ({
+          id: '7f27d54daad54846a43796f5ed008e46',
+          baseId: '26ef84e8937624450193ba443c9414bd',
+          title: '第十三次作业',
+          url: 'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+          completionType: HomeworkCompletionType.INDIVIDUAL,
+          author: {id: '2024000000', name: `名字${index}`, anonymous: true},
+          submittedContent:
+            '<!-- <span style="line-height: 24px;"> -->\r\n\t\t\t\t\t\t\t\t\t\t<span style="line-height:2;">\r\n\t\t\t\t\t\t\t\t\t\t</span>',
+          attachment: {
+            id: '1238990183_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+            name: `优秀作业${index}.pdf`,
+            downloadUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            previewUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            size: '239.54KB',
+          },
+          submittedAttachment: {
+            id: '1238990183_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+            name: `优秀作业${index}.pdf`,
+            downloadUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            previewUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            size: '239.54KB',
+          },
+          gradeAttachment: {
+            id: '1238990183_ZY_1604316692859411626215e-c233-4663-a567-a932bf4d4962',
+            name: `优秀作业${index}.pdf`,
+            downloadUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            previewUrl:
+              'https://www.apple.com/environment/pdf/Apple_Environmental_Responsibility_Report_2018.pdf',
+            size: '239.54KB',
+          },
+        })),
+      },
     ],
   },
   files: {

--- a/src/data/types/state.ts
+++ b/src/data/types/state.ts
@@ -147,6 +147,7 @@ export type Assignment = Pick<
   | 'answerContent'
   | 'answerAttachment'
   | 'url'
+  | 'excellentHomeworkList'
 > &
   CourseExtraInfo;
 export interface AssignmentsState {

--- a/src/screens/AssignmentDetail.tsx
+++ b/src/screens/AssignmentDetail.tsx
@@ -326,7 +326,7 @@ const AssignmentDetail: React.FC<Props> = ({route, navigation}) => {
                     )}
                     <Caption>
                       {isLocaleChinese()
-                        ? `${excellentHomework.author.name} 的优秀作业`
+                        ? `${excellentHomework.author.name}的优秀作业`
                         : `excellent homework by ${excellentHomework.author.name}`}
                     </Caption>
                   </View>

--- a/src/screens/AssignmentDetail.tsx
+++ b/src/screens/AssignmentDetail.tsx
@@ -307,6 +307,9 @@ const AssignmentDetail: React.FC<Props> = ({route, navigation}) => {
             const attachment =
               excellentHomework.gradeAttachment ||
               excellentHomework.submittedAttachment;
+            const authorName = excellentHomework.author.anonymous
+              ? t('anonymous')
+              : excellentHomework.author.name;
             return (
               <>
                 <View style={[styles.section, styles.iconButton]}>
@@ -326,8 +329,8 @@ const AssignmentDetail: React.FC<Props> = ({route, navigation}) => {
                     )}
                     <Caption>
                       {isLocaleChinese()
-                        ? `${excellentHomework.author.name}的优秀作业`
-                        : `excellent homework by ${excellentHomework.author.name}`}
+                        ? `${authorName}的优秀作业`
+                        : `excellent homework by ${authorName}`}
                     </Caption>
                   </View>
                 </View>

--- a/src/screens/AssignmentDetail.tsx
+++ b/src/screens/AssignmentDetail.tsx
@@ -65,6 +65,7 @@ const AssignmentDetail: React.FC<Props> = ({route, navigation}) => {
     answerAttachment,
     answerContent,
     disableAnimation,
+    excellentHomeworkList,
   } = route.params;
 
   const html = useMemo(
@@ -301,6 +302,39 @@ const AssignmentDetail: React.FC<Props> = ({route, navigation}) => {
             <Divider />
           </>
         )}
+        {excellentHomeworkList &&
+          excellentHomeworkList.map(excellentHomework => {
+            const attachment =
+              excellentHomework.gradeAttachment ||
+              excellentHomework.submittedAttachment;
+            return (
+              <>
+                <View style={[styles.section, styles.iconButton]}>
+                  <MaterialCommunityIcons
+                    style={styles.icon}
+                    name="medal"
+                    color={theme.colors.primary}
+                    size={17}
+                  />
+                  <View style={Styles.flex1}>
+                    {attachment && (
+                      <TextButton
+                        style={[Styles.spacey1, styles.textPaddingRight]}
+                        onPress={() => handleFileOpen(attachment)}>
+                        {attachment.name}
+                      </TextButton>
+                    )}
+                    <Caption>
+                      {isLocaleChinese()
+                        ? `${excellentHomework.author.name} 的优秀作业`
+                        : `excellent homework by ${excellentHomework.author.name}`}
+                    </Caption>
+                  </View>
+                </View>
+                <Divider />
+              </>
+            );
+          })}
         <AutoHeightWebView
           source={{
             html,


### PR DESCRIPTION
增加显示优秀作业的功能，包括作业详情界面和作业列表的 card，已经在 MacOS、iPhone、iPad 初步测试完成。

显示效果如下：

MacOS：
<img width="610" alt="MacOS" src="https://github.com/user-attachments/assets/cc5d3f4d-ea1e-4bb4-bbff-a3d742a64bba" />

iPhone：
<img height="610" alt="iPhone" src="https://github.com/user-attachments/assets/4882e7d2-ee3a-4d66-9300-1f2dc404c254" />
<img height="610" alt="iPhone" src="https://github.com/user-attachments/assets/8267ef4f-316c-4a41-9944-20cc142a870b" />

iPad：
<img width="610" alt="iPad" src="https://github.com/user-attachments/assets/e08fd3f9-fc5e-42b6-ba06-a88feb6c5756" />