### PR TITLE
Escape single quotes in password

### DIFF
--- a/src/screens/SSO.tsx
+++ b/src/screens/SSO.tsx
@@ -41,7 +41,7 @@ const SSO: React.FC<Props> = ({ route, navigation }) => {
 
   const injectedJs = ssoCustomScript
     .replaceAll('${username}', username)
-    .replaceAll('${password}', password)
+    .replaceAll("'${password}'", JSON.stringify(password)) // `password` may contain single quotes
     .replaceAll(
       '${deviceName}',
       `${DeviceInfo.model()},learnX/${packageJson.version}`,


### PR DESCRIPTION
This fix makes use of JSON.stringify and replaces `'${password}'` (with quotes) by the stringified string. However, this could still be fragile in the sense that we cannot make sure that `${password}` in `sso.js` will always be surrounded in single quotes.

Credits to @zesty-fox for discovering and reporting this bug.