### PR TITLE
fix: remove fullScreenModal presentation for SSO screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -421,7 +421,6 @@ const LoginStack = () => (
       options={{
         headerLeft: () => <BackButton />,
         ...getTitleOptions(t('sso')),
-        presentation: 'fullScreenModal',
       }}
     />
   </LoginNavigator.Navigator>


### PR DESCRIPTION
WARNING: 这是一个修改，对应的是我在https://github.com/robertying/learnX/issues/1108 提的这个issue，我尝试用ai修改了一下，在我这里编译跑通了，请reviewer再仔细确认一下修改是否得当，感谢！

On macOS 26.3.1(a), the fullScreenModal presentation mode in react-native-screens fails silently on Mac Catalyst — navigation is called but the screen never renders. Switching to the default push presentation resolves the issue.

Fixes #1108

Made-with: Cursor